### PR TITLE
feat: cicd github action 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,4 +66,4 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ env.CF_DISTRIBUTION_ID }} \
-            --paths "/index.html" "/"
+            --paths "/index.html" "/" "/favicon-32x32.png"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 배포 워크플로우 추가: main 브랜치 푸시 및 수동 실행 시 S3로 정적 사이트 배포, CloudFront 무효화 수행
  * OIDC 기반 AWS 자격 구성 적용 및 배포 파이프라인에 Node/pnpm 설치·빌드 단계 포함
  * 자산별 캐시 정책 분리: assets/는 장기 캐시(immutable), 나머지 파일과 index.html은 각각 적절한 캐시 제어로 업로드
  * S3 동기화 시 삭제 옵션 적용(delete-on-sync) 및 브랜치별 동시성 취소로 중복 배포 방지
  * 배포 후 특정 경로(/, /index.html, /favicon-32x32.png) CloudFront 무효화 수행
<!-- end of auto-generated comment: release notes by coderabbit.ai -->